### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/panasonic_ac_saa4/manifest.json
+++ b/custom_components/panasonic_ac_saa4/manifest.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.0",
   "domain": "panasonic_ac_saa4",
   "name": "Panasonic SMART",
   "config_flow": true,


### PR DESCRIPTION
新贈 manifest 中 被標示為必要的 version 資訊
As of Home Assistant 2021.6, custom integration without version key in manifest.json would no longer be loaded.

Related Informations:
Breaking Changes on HA 2021.6
Developer Blog
Block custom integrations with missing or invalid version